### PR TITLE
[REF-3630]Remove unsupported props from toast

### DIFF
--- a/customer_data_app/customer_data_app/backend/backend.py
+++ b/customer_data_app/customer_data_app/backend/backend.py
@@ -144,7 +144,7 @@ class State(rx.State):
             session.add(Customer(**self.current_user))
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {self.current_user['name']} has been added.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['name']} has been added.", position="bottom-right")
     
 
     def update_customer_to_db(self, form_data: dict):
@@ -159,7 +159,7 @@ class State(rx.State):
             session.add(customer)
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {self.current_user['name']} has been modified.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['name']} has been modified.", position="bottom-right")
 
 
     def delete_customer(self, id: int):
@@ -169,7 +169,7 @@ class State(rx.State):
             session.delete(customer)
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {customer.name} has been deleted.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {customer.name} has been deleted.", position="bottom-right")
     
     
     @rx.var(cache=True)

--- a/sales/sales/backend/backend.py
+++ b/sales/sales/backend/backend.py
@@ -125,7 +125,7 @@ class State(rx.State):
             session.add(Customer(**self.current_user))
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {self.current_user["customer_name"]} has been added.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['customer_name']} has been added.", position="bottom-right")
 
     def update_customer_to_db(self, form_data: dict):
         self.current_user.update(form_data)
@@ -139,7 +139,7 @@ class State(rx.State):
             session.add(customer)
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {self.current_user["customer_name"]} has been modified.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['customer_name']} has been modified.", position="bottom-right")
 
     def delete_customer(self, id: int):
         """Delete a customer from the database."""
@@ -149,7 +149,7 @@ class State(rx.State):
             session.delete(customer)
             session.commit()
         self.load_entries()
-        return rx.toast.info(f"User {customer.customer_name} has been deleted.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {customer.customer_name} has been deleted.", position="bottom-right")
 
     @rx.background
     async def call_openai(self):


### PR DESCRIPTION
Toast component doesnt support the `variant` prop. According to the docs, all styles should either be placed in a `style` object for regular CSS or `classNames` for tailwind 
https://sonner.emilkowal.ski/styling