### PR TITLE
Fix total_pages for empty or incompletely-loaded table to 1

### DIFF
--- a/dashboard/dashboard/backend/table_state.py
+++ b/dashboard/dashboard/backend/table_state.py
@@ -70,7 +70,7 @@ class TableState(rx.State):
     @rx.var(cache=True)
     def total_pages(self) -> int:
         return (self.total_items // self.limit) + (
-            1 if self.total_items % self.limit else 0
+            1 if self.total_items % self.limit else 1
         )
 
     @rx.var(cache=True, initial_value=[])


### PR DESCRIPTION
We are using the `table_state` backend component in an app that loads the table from an API call.

While the table is loading, the UI would display `Page 1 of 0`, because `page_number` is always at-least 1, where `total_pages` had an `else` condition setting it to 0.

This fixes that.