### PR TITLE
dashboard: fix bad filename

### DIFF
--- a/dashboard/dashboard/backend/table_state.py
+++ b/dashboard/dashboard/backend/table_state.py
@@ -96,7 +96,7 @@ class TableState(rx.State):
         self.offset = (self.total_pages - 1) * self.limit
 
     def load_entries(self):
-        with Path("item.csv").open(mode="r", encoding="utf-8") as file:
+        with Path("items.csv").open(mode="r", encoding="utf-8") as file:
             reader = csv.DictReader(file)
             self.items = [Item(**row) for row in reader]
             self.total_items = len(self.items)


### PR DESCRIPTION
```
[Reflex Backend Exception]
 Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/reflex/state.py", line 1847, in _process_event
    events = fn(**payload)
             ^^^^^^^^^^^^^
  File "/asdf/asdf/backend/table_state.py", line 99, in load_entries
    with Path("item.csv").open(mode="r", encoding="utf-8") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 1014, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'item.csv'
```