### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/check_export.yml
+++ b/.github/workflows/check_export.yml
@@ -11,6 +11,7 @@ on:
     inputs:
       reflex_dep:
         description: "Reflex dep (raw pip spec)"
+        default: "git+https://github.com/reflex-dev/reflex.git@main"
 
 jobs:
   list-templates:
@@ -54,7 +55,6 @@ jobs:
           source venv/bin/activate
 
           pip install '${{ github.event.inputs.reflex_dep || env.REFLEX_DEP }}' -r requirements.txt
-          pip install git+https://github.com/reflex-dev/reflex.git@main
 
           export OPENAI_API_KEY="dummy"
           reflex init

--- a/.github/workflows/check_export.yml
+++ b/.github/workflows/check_export.yml
@@ -1,6 +1,6 @@
 name: check-export
 env:
-  REFLEX_DEP: "reflex"
+  REFLEX_DEP: "git+https://github.com/reflex-dev/reflex.git@main"
   TELEMETRY_ENABLED: false
 on:
   push:
@@ -11,7 +11,6 @@ on:
     inputs:
       reflex_dep:
         description: "Reflex dep (raw pip spec)"
-        default: "git+https://github.com/reflex-dev/reflex.git@main"
 
 jobs:
   list-templates:

--- a/.github/workflows/create-artifacts.yml
+++ b/.github/workflows/create-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
         shell: bash
       - name: Upload zip files as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: zip-files
           path: "*.zip"
@@ -37,7 +37,7 @@ jobs:
         file: ${{ fromJson(needs.zip-and-publish.outputs.files) }}
     steps:
       - name: Download zip files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: zip-files
       - name: Debug output (file existence check)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
       uses: ./.github/workflows/list-templates.yml
 
     deploy:
+        # Can't deploy on a non-published release, so publish the release first.
+        if: ${{ !contains(github.event.release.tag_name, 'dev') }}
         needs: list-templates
         runs-on: ubuntu-latest
         environment: Cloud Deploy
@@ -24,6 +26,8 @@ jobs:
             - uses: actions/checkout@v4
               with:
                 submodules: recursive
+            - name: Set reflex version for deploy
+              run: sed -e "s/^reflex[ >=].*$/reflex==${{ github.event.release.tag_name }}/" -i ${{ matrix.folder }}/requirements.txt
             - name: Set environment variables
               id: set-env
               run: |


### PR DESCRIPTION
* use artifact v4 actions
* don't override user's requested REFLEX_DEP
* when deploying, use the reflex version associated with the tag