### PR TITLE
dashboard: Update pages during search

### DIFF
--- a/dashboard/dashboard/backend/table_state.py
+++ b/dashboard/dashboard/backend/table_state.py
@@ -62,14 +62,16 @@ class TableState(rx.State):
                     ]
                 )
             ]
-
+            self.total_items = len(items)
+        else:
+            self.total_items = len(self.items)
         return items
 
     @rx.var(cache=True)
     def page_number(self) -> int:
         return (self.offset // self.limit) + 1
 
-    @rx.var(cache=True)
+    @rx.var(cache=False)
     def total_pages(self) -> int:
         return (self.total_items // self.limit) + (
             1 if self.total_items % self.limit else 1

--- a/dashboard/dashboard/views/table.py
+++ b/dashboard/dashboard/views/table.py
@@ -149,7 +149,7 @@ def main_table() -> rx.Component:
                     width="100%",
                     variant="surface",
                     color_scheme="gray",
-                    on_change=TableState.set_search_value,
+                    on_change=[TableState.set_search_value, TableState.first_page]
                 ),
                 align="center",
                 justify="end",


### PR DESCRIPTION
This fix page number during search. Page number might be on page 5 and the user search for something that are outside current number of pages.

This commit will set page number to 1 and recalculate number of pages during search.